### PR TITLE
search by card text

### DIFF
--- a/src/predicates/index.js
+++ b/src/predicates/index.js
@@ -4,4 +4,5 @@ module.exports = {
   name: require('./matchName'),
   pow: require('./matchPower'),
   tou: require('./matchToughness'),
+  text: require('./matchText')
 };

--- a/src/predicates/matchSubstring.js
+++ b/src/predicates/matchSubstring.js
@@ -1,7 +1,10 @@
 // needle is a space-delimited string of substrings that should exist in
 // the haystack. Return true if they ALL do.
 const matchSubstring = (needle, haystack) => {
-  const lowerHaystack = haystack.toLowerCase();
+  if (!haystack) {
+    return undefined;
+  }
+ const lowerHaystack = haystack.toLowerCase(); 
   const needleArray = needle.toLowerCase().split(` `);
   return !needleArray
     .find(t => !lowerHaystack.includes(t));

--- a/src/predicates/matchText.js
+++ b/src/predicates/matchText.js
@@ -1,0 +1,9 @@
+const matchSubstring = require('./matchSubstring');
+// Includes the entire type string
+//   ?q=text:shuffle
+//   ?q=text:gain q:life
+const matchText = (needles, card) => {
+  return matchSubstring(needles, card.text);
+};
+
+module.exports = matchText;


### PR DESCRIPTION
searches by card text. currently only one word at a time, so

`/q?text:shuffle`

<img width="230" alt="screen shot 2017-08-20 at 10 23 01 am" src="https://user-images.githubusercontent.com/19597672/29495668-b2b3747a-8591-11e7-8983-7644d05e6eb4.png">

`/q/text:destroy+text:target+text:land`

<img width="229" alt="screen shot 2017-08-20 at 10 23 26 am" src="https://user-images.githubusercontent.com/19597672/29495670-b7c099ac-8591-11e7-820c-33e433ebb0c6.png">
