### PR TITLE
Rarity and setcode search

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "chai": "4.1.1",
-    "chai-http": "3.0.0",
+    "chai-http": "4.0.0",
     "codecov": "2.3.0",
     "eslint": "4.2.0",
     "gulp": "3.9.1",

--- a/src/card-api.js
+++ b/src/card-api.js
@@ -20,7 +20,7 @@ const getCardImage = (req, res, next) => {
         .on(`error`, (err) => next(err))
         .pipe(res);
     } else {
-      if (card.isRandom)
+      if (card.isRandomOrVersioned)
         res.set(`Cache-Control`, `no-cache, no-store`);
       request.get(url).pipe(res);
     }

--- a/src/mtg-data.js
+++ b/src/mtg-data.js
@@ -46,11 +46,17 @@ class MtgData {
   }
 
   getSingleCardFromQuery(query) {
-    const searchQuery = query.q || ``;
     const name = query.card || ``;
     const useGoof = query.goof !== undefined;
-    const normalizedName = MtgData.normalizeName(name);
+    const normalizedName = MtgData.normalizeName(name);  
     const sort = query.sort || `none`;
+    let searchQuery = query.q || ``;
+
+    // if sort is random, use card search instead of the static card map
+    if (!searchQuery && sort === RANDOM) {
+      searchQuery = `name:"${normalizedName}"`;
+    }
+
     if (searchQuery) {
       let listToSearch = this.cardList;
       if (sort === RANDOM)

--- a/src/mtg-data.js
+++ b/src/mtg-data.js
@@ -9,7 +9,11 @@ const RANDOM = `random`;
 class MtgData {
   constructor(allSets) {
     const cardListOriginal = _.flatMap(allSets, set => {
-      set.cards.forEach(card => card.set = set.name);
+      set.cards.forEach(card => {
+        card.set = set.name;
+        card.code = set.code;
+      });    
+
       return set.cards;
     });
 

--- a/src/mtg-data.js
+++ b/src/mtg-data.js
@@ -12,6 +12,7 @@ class MtgData {
       set.cards.forEach(card => {
         card.set = set.name;
         card.code = set.code;
+        card.border = card.border || set.border
       });    
 
       return set.cards;

--- a/src/mtg-data.js
+++ b/src/mtg-data.js
@@ -5,6 +5,7 @@ const shuffle = require('./shuffle');
 
 const MULTIVERSE_URL = 'http://gatherer.wizards.com/Handlers/Image.ashx?type=card&multiverseid=';
 const RANDOM = `random`;
+const ANY = `any`;
 
 class MtgData {
   constructor(allSets) {
@@ -55,20 +56,29 @@ class MtgData {
     const useGoof = query.goof !== undefined;
     const normalizedName = MtgData.normalizeName(name);  
     const sort = query.sort || `none`;
+
+    // alias for the 'code' predicate (three-letter set code)
+    // for use with 'card' parameter (i.e. image search)
+    const version = query.version; 
+
     let searchQuery = query.q || ``;
 
-    // if sort is random, use card search instead of the static card map
-    if (!searchQuery && sort === RANDOM) {
+    // if sort is random or a version is requested, 
+    // use card search instead of the static card map
+    if (!searchQuery && (sort === RANDOM || version !== undefined)) {
       searchQuery = `name:"${normalizedName}"`;
+      if (version !== ANY && version !== undefined) {
+        searchQuery += ` code:${version}`
+      }
     }
 
     if (searchQuery) {
       let listToSearch = this.cardList;
-      if (sort === RANDOM)
+      if (sort === RANDOM || version === ANY)
         shuffle(listToSearch);
       let card = search(listToSearch, searchQuery, 1)[0];
       if (card)
-        card.isRandom = sort === RANDOM;
+        card.isRandomOrVersioned = (sort === RANDOM) || (version !== undefined);
       return card;
     }
     if (useGoof && goofs && goofs[normalizedName])

--- a/src/mtg-data.js
+++ b/src/mtg-data.js
@@ -100,10 +100,6 @@ class MtgData {
     return undefined;
   }
 
-  getCardMap() {
-    return this.cardMap;
-  }
-
   getCardFromMap(name) {
     return this.cardMap[name];
   }

--- a/src/predicates/index.js
+++ b/src/predicates/index.js
@@ -10,5 +10,6 @@ module.exports = {
   actualCards: require('./matchActualCards'),
   requireImage: require('./matchRequireImage'),
   color: require('./matchColor'),
-  code: require('./matchSetCode')
+  code: require('./matchSetCode'),
+  rarity: require('./matchRarity')
 };

--- a/src/predicates/index.js
+++ b/src/predicates/index.js
@@ -9,5 +9,6 @@ module.exports = {
   layout: require('./matchLayout'),
   actualCards: require('./matchActualCards'),
   requireImage: require('./matchRequireImage'),
-  color: require('./matchColor')
+  color: require('./matchColor'),
+  code: require('./matchSetCode')
 };

--- a/src/predicates/index.js
+++ b/src/predicates/index.js
@@ -11,5 +11,6 @@ module.exports = {
   requireImage: require('./matchRequireImage'),
   color: require('./matchColor'),
   code: require('./matchSetCode'),
-  rarity: require('./matchRarity')
+  rarity: require('./matchRarity'),
+  border: require('./matchBorder')
 };

--- a/src/predicates/matchBorder.js
+++ b/src/predicates/matchBorder.js
@@ -1,0 +1,9 @@
+const matchString = require('./matchString');
+
+// black, white, silver
+const matchBorder = (needles, card) => {
+  console.log(needles + '? ' + card.border);
+  return matchString(needles, card.border);
+};
+
+module.exports = matchBorder;

--- a/src/predicates/matchBorder.js
+++ b/src/predicates/matchBorder.js
@@ -2,7 +2,6 @@ const matchString = require('./matchString');
 
 // black, white, silver
 const matchBorder = (needles, card) => {
-  console.log(needles + '? ' + card.border);
   return matchString(needles, card.border);
 };
 

--- a/src/predicates/matchRarity.js
+++ b/src/predicates/matchRarity.js
@@ -1,0 +1,18 @@
+const matchString = require('./matchString');
+
+// common, uncommon, rare, mythic, basic, special
+const rarities = {
+  common: 'Common',
+  uncommon: 'Uncommon',
+  rare: 'Rare',    
+  mythic: 'Mythic Rare',    
+  basic: 'Basic Land',
+  special: 'Special'
+};
+
+const matchRarity = (needles, card) => {
+  normalizedNeedles = '!' + rarities[needles] || 'invalid';
+  return matchString(normalizedNeedles, card.rarity);
+};
+
+module.exports = matchRarity;

--- a/src/predicates/matchRarity.js
+++ b/src/predicates/matchRarity.js
@@ -11,7 +11,7 @@ const rarities = {
 };
 
 const matchRarity = (needles, card) => {
-  normalizedNeedles = '!' + rarities[needles] || 'invalid';
+  let normalizedNeedles = rarities[needles] ? '!' + rarities[needles] : 'invalid';
   return matchString(normalizedNeedles, card.rarity);
 };
 

--- a/src/predicates/matchSetCode.js
+++ b/src/predicates/matchSetCode.js
@@ -1,0 +1,9 @@
+const matchString = require('./matchString');
+// Uses three-letter codes as listed in https://mtgjson.com/json/SetCodes.json
+//   ?q=code:NPH
+//   ?q=code:BOK
+const matchCode = (needles, card) => {
+  return matchString(needles, card.code);
+};
+
+module.exports = matchCode;

--- a/test/integration_tests/test-border.js
+++ b/test/integration_tests/test-border.js
@@ -22,16 +22,16 @@ const validateMtgJson = (res) => {
 };
 
 describe('border search', () => {
-  it('should return at all silver-bordered cards', (done) => {
+  it('should return at all white-bordered cards', (done) => {
     app.getReady().then(() => {
       chai.request(server)
-        .get('/card/json?unique&q=border:silver&limit=10')
+        .get('/card/json?unique&q=border:white&limit=10')
         .end((err, res) => {
           validateMtgJson(res);
           res.body.length.should.equal(10);
-          res.body.forEach(c => c.border.toLowerCase().should.equal(`silver`));         
+          res.body.forEach(c => c.border.toLowerCase().should.equal(`white`));         
           done();
         });
     });
-  });  
+  }).timeout(3000);  
 });

--- a/test/integration_tests/test-border.js
+++ b/test/integration_tests/test-border.js
@@ -1,0 +1,37 @@
+'use strict';
+process.env.NODE_ENV = 'test';
+
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+chai.should();  // Allows use of `should` in tests
+chai.use(chaiHttp);
+
+const app = require('../../app');
+const server = app.getExpress();
+app.listenRandomPort().then((port) => {
+  console.log(`Tests running on port ${port}`);
+});
+
+const validateMtgJson = (res) => {
+  res.should.have.status(200);
+  res.type.should.equal(`application/json`);
+  res.body.should.be.a('array');
+  res.body[0].should.have.property('name');
+  res.body[0].should.have.property('multiverseid');
+  res.body[0].should.have.property('imageUrl');
+};
+
+describe('border search', () => {
+  it('should return at all silver-bordered cards', (done) => {
+    app.getReady().then(() => {
+      chai.request(server)
+        .get('/card/json?unique&q=border:silver')
+        .end((err, res) => {
+          validateMtgJson(res);
+          res.body.length.should.equal(25);
+          res.body.forEach(c => c.border.toLowerCase().should.equal(`silver`));         
+          done();
+        });
+    });
+  });  
+});

--- a/test/integration_tests/test-border.js
+++ b/test/integration_tests/test-border.js
@@ -25,10 +25,10 @@ describe('border search', () => {
   it('should return at all silver-bordered cards', (done) => {
     app.getReady().then(() => {
       chai.request(server)
-        .get('/card/json?unique&q=border:silver')
+        .get('/card/json?unique&q=border:silver&limit=10')
         .end((err, res) => {
           validateMtgJson(res);
-          res.body.length.should.equal(25);
+          res.body.length.should.equal(10);
           res.body.forEach(c => c.border.toLowerCase().should.equal(`silver`));         
           done();
         });

--- a/test/integration_tests/test-cmc.js
+++ b/test/integration_tests/test-cmc.js
@@ -22,28 +22,28 @@ const validateMtgJson = (res) => {
 };
 
 describe('cmc search', () => {
-  it('should return 4 cards with cmc = 15', (done) => {
+  it('should return 5 cards with cmc = 15', (done) => {
     app.getReady().then(() => {
       chai.request(server)
         .get('/card/json?unique&q=cmc:=15')
         .end((err, res) => {
           validateMtgJson(res);
           // Cards with cost 15
-          res.body.length.should.equal(4);
+          res.body.length.should.equal(5);
           res.body.forEach(c => c.cmc.should.equal(15));
           done();
         });
     });
   });
 
-  it('should return 4 cards with cmc 15', (done) => {
+  it('should return 5 cards with cmc 15', (done) => {
     app.getReady().then(() => {
       chai.request(server)
         .get('/card/json?unique&q=cmc:15')
         .end((err, res) => {
           validateMtgJson(res);
           // Cards with cost 15
-          res.body.length.should.equal(4);
+          res.body.length.should.equal(5);
           res.body.forEach(c => c.cmc.should.equal(15));
           done();
         });
@@ -92,14 +92,14 @@ describe('cmc search', () => {
     });
   });
 
-  it('should return 2 cards cmc >= 15', (done) => {
+  it('should return 7 cards cmc >= 15', (done) => {
     app.getReady().then(() => {
       chai.request(server)
         .get('/card/json?unique&q=cmc:>=15')
         .end((err, res) => {
           validateMtgJson(res);
           // Cards with cost 15 or higher
-          res.body.length.should.equal(6);
+          res.body.length.should.equal(7);
           res.body.forEach(c => c.cmc.should.be.at.least(15));
           done();
         });

--- a/test/integration_tests/test-color.js
+++ b/test/integration_tests/test-color.js
@@ -22,13 +22,13 @@ const validateMtgJson = (res) => {
 };
 
 describe('color search', () => {
-  it('should return 12 cards with exact mana red, white, blue', (done) => {
+  it('should return 13 cards with exact mana red, white, blue', (done) => {
     app.getReady().then(() => {
       chai.request(server)
         .get('/card/json?unique&q=color:!rwum')
         .end((err, res) => {
           validateMtgJson(res);
-          res.body.length.should.equal(12);
+          res.body.length.should.equal(13);
           done();
         });
     });

--- a/test/integration_tests/test-rarity.js
+++ b/test/integration_tests/test-rarity.js
@@ -1,0 +1,50 @@
+'use strict';
+process.env.NODE_ENV = 'test';
+
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+chai.should();  // Allows use of `should` in tests
+chai.use(chaiHttp);
+
+const app = require('../../app');
+const server = app.getExpress();
+app.listenRandomPort().then((port) => {
+  console.log(`Tests running on port ${port}`);
+});
+
+const validateMtgJson = (res) => {
+  res.should.have.status(200);
+  res.type.should.equal(`application/json`);
+  res.body.should.be.a('array');
+  res.body[0].should.have.property('name');
+  res.body[0].should.have.property('multiverseid');
+  res.body[0].should.have.property('imageUrl');
+};
+
+describe('rarity search', () => {
+  it('should return 0 cards when an invalid rarity is specified', (done) => {
+    app.getReady().then(() => {
+      chai.request(server)
+        .get('/card/json?unique&q=rarity:extraterrestrial')
+        .end((err, res) => {
+          res.type.should.equal(`application/json`);
+          res.body.should.be.a('array');
+          res.body.length.should.equal(0);
+          done();
+        });
+    });
+  });
+
+  it('should return at all mythic cards', (done) => {
+    app.getReady().then(() => {
+      chai.request(server)
+        .get('/card/json?unique&q=rarity:mythic')
+        .end((err, res) => {
+          validateMtgJson(res);
+          res.body.length.should.equal(25);
+          res.body.forEach(c => c.rarity.toLowerCase().should.equal(`mythic rare`));         
+          done();
+        });
+    });
+  });  
+});

--- a/test/integration_tests/test-search.js
+++ b/test/integration_tests/test-search.js
@@ -213,12 +213,12 @@ describe('search', () => {
       const requester = chai.request(server).keepOpen();
 
       let testResult;
-      const images = []; 
+      const results = []; 
       try {
-        for (var i = 0; i < 3; i++) {
-          await requester.get(searchUrl).then(res => validateImageResult(res, images));  
+        for (var i = 0; i < 2; i++) {
+          await requester.get(searchUrl).then(res => validateImageResult(res, results));  
         }
-        const uniqueImages = images.map(images => images.imageSize).filter((value, index, ary) => ary.indexOf(value) === index);
+        const uniqueImages = results.map(images => images.imageSize).filter((value, index, ary) => ary.indexOf(value) === index);
         uniqueImages.should.have.lengthOf(1);
       } catch(e) {
         testResult = e;    
@@ -228,18 +228,18 @@ describe('search', () => {
     });
   }); 
 
-  it('should return images with different lengths for random image search', (done) => {
+  it('should return images with different file sizes for random image search', (done) => {
     app.getReady().then(async () => {
       const searchUrl = '/image?card=Mountain&sort=random';      
       const requester = chai.request(server).keepOpen();
 
       let testResult;
-      const images = []; 
+      const results = []; 
       try {
         for (var i = 0; i < 3; i++) {
-          await requester.get(searchUrl).then(res => validateImageResult(res, images));  
+          await requester.get(searchUrl).then(res => validateImageResult(res, results));  
         }
-        const uniqueImages = images.map(images => images.imageSize).filter((value, index, ary) => ary.indexOf(value) === index);
+        const uniqueImages = results.map(images => images.imageSize).filter((value, index, ary) => ary.indexOf(value) === index);
         uniqueImages.should.have.lengthOf.at.least(2);
       } catch(e) {
         testResult = e;    
@@ -247,5 +247,44 @@ describe('search', () => {
       requester.close();
       done(testResult);
     });
-  });  
+  });
+
+  it('should return correct image for version-specific image search', (done) => {
+    app.getReady().then(async () => {
+      const searchUrl = '/image?card=Icy%20Manipulator&version=ice';      
+      const requester = chai.request(server).keepOpen();
+ 
+      let testResult;
+      const expectedImageSize = 35402;     
+      const results = []; 
+      try {
+        await requester.get(searchUrl).then(res => validateImageResult(res, results));         
+        results[0].imageSize.should.equal(expectedImageSize);
+      } catch(e) {
+        testResult = e;    
+      }
+      requester.close();
+      done(testResult);
+    });
+  });
+
+  it('should return images with file sizes for "any version" image search', (done) => {
+    app.getReady().then(async () => {
+      const searchUrl = '/image?card=Mountain&version=any';      
+      const requester = chai.request(server).keepOpen();
+      let testResult;
+      const results = []; 
+      try {
+        for (var i = 0; i < 3; i++) {
+          await requester.get(searchUrl).then(res => validateImageResult(res, results));  
+        }
+        const uniqueImages = results.map(images => images.imageSize).filter((value, index, ary) => ary.indexOf(value) === index);
+        uniqueImages.should.have.lengthOf.at.least(2);
+      } catch(e) {
+        testResult = e;    
+      }
+      requester.close();
+      done(testResult);
+    });
+  });
 });

--- a/test/integration_tests/test-search.js
+++ b/test/integration_tests/test-search.js
@@ -21,6 +21,16 @@ const validateMtgJson = (res) => {
   res.body[0].should.have.property('imageUrl');
 };
 
+const validateImageResult = (res, resultAccumulator) => {
+  res.should.have.status(200);
+  res.type.should.equal(`image/jpeg`);
+  res.header.should.haveOwnProperty('content-length');
+  const imageSize = parseInt(res.header['content-length']);
+  imageSize.should.be.greaterThan(0);
+
+  resultAccumulator.push({imageSize: imageSize});
+};
+
 describe('search', () => {
   it('should return 1 card with detailed search', (done) => {
     app.getReady().then(() => {
@@ -196,4 +206,46 @@ describe('search', () => {
         });
     });
   });
+
+  it('should return the same image when a search is repeated', (done) => {
+    app.getReady().then(async () => {
+      const searchUrl = '/image?card=Mountain';      
+      const requester = chai.request(server).keepOpen();
+
+      let testResult;
+      const images = []; 
+      try {
+        for (var i = 0; i < 3; i++) {
+          await requester.get(searchUrl).then(res => validateImageResult(res, images));  
+        }
+        const uniqueImages = images.map(images => images.imageSize).filter((value, index, ary) => ary.indexOf(value) === index);
+        uniqueImages.should.have.lengthOf(1);
+      } catch(e) {
+        testResult = e;    
+      }
+      requester.close();
+      done(testResult);
+    });
+  }); 
+
+  it('should return images with different lengths for random image search', (done) => {
+    app.getReady().then(async () => {
+      const searchUrl = '/image?card=Mountain&sort=random';      
+      const requester = chai.request(server).keepOpen();
+
+      let testResult;
+      const images = []; 
+      try {
+        for (var i = 0; i < 3; i++) {
+          await requester.get(searchUrl).then(res => validateImageResult(res, images));  
+        }
+        const uniqueImages = images.map(images => images.imageSize).filter((value, index, ary) => ary.indexOf(value) === index);
+        uniqueImages.should.have.lengthOf.at.least(2);
+      } catch(e) {
+        testResult = e;    
+      }
+      requester.close();
+      done(testResult);
+    });
+  });  
 });

--- a/test/integration_tests/test-search.js
+++ b/test/integration_tests/test-search.js
@@ -226,7 +226,7 @@ describe('search', () => {
       requester.close();
       done(testResult);
     });
-  }); 
+  }).timeout(3000);; 
 
   it('should return images with different file sizes for random image search', (done) => {
     app.getReady().then(async () => {
@@ -247,7 +247,7 @@ describe('search', () => {
       requester.close();
       done(testResult);
     });
-  });
+  }).timeout(3000);
 
   it('should return correct image for version-specific image search', (done) => {
     app.getReady().then(async () => {
@@ -266,9 +266,9 @@ describe('search', () => {
       requester.close();
       done(testResult);
     });
-  });
+  }).timeout(3000);
 
-  it('should return images with file sizes for "any version" image search', (done) => {
+  it('should return images with different file sizes for "any version" image search', (done) => {
     app.getReady().then(async () => {
       const searchUrl = '/image?card=Mountain&version=any';      
       const requester = chai.request(server).keepOpen();
@@ -286,5 +286,5 @@ describe('search', () => {
       requester.close();
       done(testResult);
     });
-  });
+  }).timeout(3000);
 });

--- a/test/integration_tests/test-set-code.js
+++ b/test/integration_tests/test-set-code.js
@@ -1,0 +1,37 @@
+'use strict';
+process.env.NODE_ENV = 'test';
+
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+chai.should();  // Allows use of `should` in tests
+chai.use(chaiHttp);
+
+const app = require('../../app');
+const server = app.getExpress();
+app.listenRandomPort().then((port) => {
+  console.log(`Tests running on port ${port}`);
+});
+
+const validateMtgJson = (res) => {
+  res.should.have.status(200);
+  res.type.should.equal(`application/json`);
+  res.body.should.be.a('array');
+  res.body[0].should.have.property('name');
+  res.body[0].should.have.property('multiverseid');
+  res.body[0].should.have.property('imageUrl');
+};
+
+describe('set code search search', () => {
+  it('should return all 15 cards from FTV: Dragons', (done) => {
+    app.getReady().then(() => {
+      chai.request(server)
+        .get('/card/json?unique&q=code:drb')
+        .end((err, res) => {
+          validateMtgJson(res);
+          res.body.length.should.equal(15);
+          res.body.forEach(c => c.set.toLowerCase().should.equal(`From the Vault: Dragons`.toLowerCase()));         
+          done();
+        });
+    });
+  });  
+});

--- a/test/integration_tests/test-type.js
+++ b/test/integration_tests/test-type.js
@@ -22,26 +22,26 @@ const validateMtgJson = (res) => {
 };
 
 describe('type search', () => {
-  it('should return 12 unicorns', (done) => {
+  it('should return 13 unicorns', (done) => {
     app.getReady().then(() => {
       chai.request(server)
         .get('/card/json?unique&q=t:Unicorn')
         .end((err, res) => {
           validateMtgJson(res);
-          res.body.length.should.equal(12);
+          res.body.length.should.equal(13);
           res.body.forEach(c => c.type.should.contain(`Unicorn`));
           done();
         });
     });
   });
 
-  it('should return 19 legendary goblins', (done) => {
+  it('should return 20 legendary goblins', (done) => {
     app.getReady().then(() => {
       chai.request(server)
         .get('/card/json?unique&q=t:Goblin t:Legendary')
         .end((err, res) => {
           validateMtgJson(res);
-          res.body.length.should.equal(19);
+          res.body.length.should.equal(20);
           res.body.forEach(c => c.type.should.contain(`Legendary`));
           res.body.forEach(c => c.type.should.contain(`Goblin`));
           done();
@@ -49,12 +49,12 @@ describe('type search', () => {
     });
   });
 
-  it('should return 9 legendary artifact creatures', (done) => {
+  it('should return 11 legendary artifact creatures', (done) => {
     chai.request(server)
       .get('/card/json?unique&q=t:Creature t:Legendary t:Artifact')
       .end((err, res) => {
         validateMtgJson(res);
-        res.body.length.should.equal(10);
+        res.body.length.should.equal(11);
         res.body.forEach(c => c.type.should.contain(`Legendary`));
         res.body.forEach(c => c.type.should.contain(`Artifact`));
         res.body.forEach(c => c.type.should.contain(`Creature`));


### PR DESCRIPTION
- search by set code, rarity, and border color
- enable random sort for single card query
- image search by set code

By Code:
- `/card/html?sort=random&q=code:PLC`
- `/image?card=Dark+Ritual&version=ICE`

By Rarity:
- `/card/html?sort=random&q=t:sorcery+rarity:mythic`

By Border Color:
- `/card/html?sort=random&q=border:silver`

Random image search:
- `/image?card=Dark+Ritual&sort=random`
- `/image?card=Counterspell&version=any`

